### PR TITLE
fix: remove comment cleanup status step from PR cleanup workflow

### DIFF
--- a/templates/github/workflows/pr-cleanup.yml
+++ b/templates/github/workflows/pr-cleanup.yml
@@ -71,20 +71,3 @@ jobs:
             echo "ℹ️ PR deployment folder ${PR_FOLDER_NAME} not found, nothing to clean up"
           fi
 
-      - name: Comment cleanup status
-        if: always()
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            const status = '${{ job.status }}' === 'success' ? '✅' : '❌';
-            const message = '${{ job.status }}' === 'success'
-              ? `PR deployment folder \`pr-${{ github.event.pull_request.number }}\` has been cleaned up from S3`
-              : `Failed to clean up PR deployment folder \`pr-${{ github.event.pull_request.number }}\``;
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `🧹 **PR Cleanup:** ${status} ${message}`
-            })


### PR DESCRIPTION
- Removes the failing 'Comment cleanup status' step that attempted to comment on closed PRs
- The step was causing workflow failures since PRs are already closed when cleanup runs
- The cleanup action's primary purpose is resource cleanup, not status reporting
- Workflow now completes successfully without unnecessary comment attempts